### PR TITLE
fix(docs): correct "Prepraration" to "Preparation" in README (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We provide **two models** of varying scales for robust and consistent video dept
 
 ## Usage
 
-### Prepraration
+### Preparation
 
 ```bash
 git clone https://github.com/DepthAnything/Video-Depth-Anything


### PR DESCRIPTION
- The heading "Prepraration" in the README is misspelled.

- Correcting it to "Preparation" improves the clarity and professionalism of the documentation.