### PR TITLE
Support autocast inference, grayscale, NPZ and EXR output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ We provide **two models** of varying scales for robust and consistent video dept
 
 | Model | Params | Checkpoint | Latency (ms) | GPU VRAM (GB) |
 |:-|:-:|:-:|:-:|:-:|
-| Video-Depth-Anything-V2-Small | 28.4M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/resolve/main/video_depth_anything_vits.pth?download=true) | 9.1(fp32), 7.5(fp16) | 7.3(fp32), 6.8(fp16) |
-| Video-Depth-Anything-V2-Large | 381.8M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Large/resolve/main/video_depth_anything_vitl.pth?download=true) | 67(fp32), 14(fp16) | 26.7(fp32), 23.6(fp16) |
+| Video-Depth-Anything-V2-Small | 28.4M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/resolve/main/video_depth_anything_vits.pth?download=true) | 9.1(fp32)<br>7.5(fp16) | 7.3(fp32)<br>6.8(fp16) |
+| Video-Depth-Anything-V2-Large | 381.8M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Large/resolve/main/video_depth_anything_vitl.pth?download=true) | 67(fp32)<br>14(fp16) | 26.7(fp32)<br>23.6(fp16) |
 
 The Latency and GPU VRAM results are obtained on a single A100 GPU with input of shape 1 x 32 x 518 × 518.
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,48 @@ This work presents **Video Depth Anything** based on [Depth Anything V2](https:/
 - **2025-01-21:** Paper, project page, code, models, and demo are all released.
 
 
+## Release Notes
+- **2025-02-08:** 🚀🚀🚀 Inference speed and memory usage improvement
+  <table>
+    <thead>
+      <tr>
+        <th rowspan="2" style="text-align: center;">Model</th>
+        <th colspan="2">Latency (ms)</th>
+        <th colspan="2">GPU VRAM (GB)</th>
+      </tr>
+      <tr>
+        <th>FP32</th>
+        <th>FP16</th>
+        <th>FP32</th>
+        <th>FP16</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Video-Depth-Anything-V2-Small</td>
+        <td>9.1</td>
+        <td><strong>7.5</strong></td>
+        <td>7.3</td>
+        <td><strong>6.8</strong></td>
+      </tr>
+      <tr>
+        <td>Video-Depth-Anything-V2-Large</td>
+        <td>67</td>
+        <td><strong>14</strong></td>
+        <td>26.7</td>
+        <td><strong>23.6</strong></td>
+    </tbody>
+  </table>
+
+  The Latency and GPU VRAM results are obtained on a single A100 GPU with input of shape 1 x 32 x 518 × 518.
+
 ## Pre-trained Models
 We provide **two models** of varying scales for robust and consistent video depth estimation:
 
-| Model | Params | Checkpoint | Latency (ms) | GPU VRAM (GB) |
-|:-|:-:|:-:|:-:|:-:|
-| Video-Depth-Anything-V2-Small | 28.4M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/resolve/main/video_depth_anything_vits.pth?download=true) | 9.1(fp32)<br>7.5(fp16) | 7.3(fp32)<br>6.8(fp16) |
-| Video-Depth-Anything-V2-Large | 381.8M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Large/resolve/main/video_depth_anything_vitl.pth?download=true) | 67(fp32)<br>14(fp16) | 26.7(fp32)<br>23.6(fp16) |
-
-The Latency and GPU VRAM results are obtained on a single A100 GPU with input of shape 1 x 32 x 518 × 518.
+| Model | Params | Checkpoint |
+|:-|-:|:-:|
+| Video-Depth-Anything-V2-Small | 28.4M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/resolve/main/video_depth_anything_vits.pth?download=true) |
+| Video-Depth-Anything-V2-Large | 381.8M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Large/resolve/main/video_depth_anything_vitl.pth?download=true) |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ This work presents **Video Depth Anything** based on [Depth Anything V2](https:/
 ## Pre-trained Models
 We provide **two models** of varying scales for robust and consistent video depth estimation:
 
-| Model | Params | Checkpoint |
-|:-|-:|:-:|
-| Video-Depth-Anything-V2-Small | 28.4M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/resolve/main/video_depth_anything_vits.pth?download=true) |
-| Video-Depth-Anything-V2-Large | 381.8M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Large/resolve/main/video_depth_anything_vitl.pth?download=true) |
+| Model | Params | Checkpoint | Latency (ms) | GPU VRAM (GB) |
+|:-|:-:|:-:|:-:|:-:|
+| Video-Depth-Anything-V2-Small | 28.4M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/resolve/main/video_depth_anything_vits.pth?download=true) | 9.1(fp32), 7.5(fp16) | 7.3(fp32), 6.8(fp16) |
+| Video-Depth-Anything-V2-Large | 381.8M | [Download](https://huggingface.co/depth-anything/Video-Depth-Anything-Large/resolve/main/video_depth_anything_vitl.pth?download=true) | 67(fp32), 14(fp16) | 26.7(fp32), 23.6(fp16) |
 
+The Latency and GPU VRAM results are obtained on a single A100 GPU with input of shape 1 x 32 x 518 × 518.
 
 ## Usage
 
@@ -53,6 +54,19 @@ bash get_weights.sh
 ```bash
 python3 run.py --input_video ./assets/example_videos/davis_rollercoaster.mp4 --output_dir ./outputs --encoder vitl
 ```
+
+Options:
+- `--input_video`: path of input video
+- `--output_dir`: path to save the output results
+- `--input_size` (optional): By default, we use input size `518` for model inference.
+- `--max_res` (optional): By default, we use maximum resolution `1280` for model inference.
+- `--encoder` (optional): `vits` for Video-Depth-Anything-V2-Small, `vitl` for Video-Depth-Anything-V2-Large.
+- `--max_len` (optional): maximum length of the input video, `-1` means no limit
+- `--target_fps` (optional): target fps of the input video, `-1` means the original fps
+- `--fp32` (optional): Use `fp32` precision for inference. By default, we use `fp16`.
+- `--grayscale` (optional): Save the grayscale depth map, without applying color palette.
+- `--save_npz` (optional): Save the depth map in `npz` format.
+- `--save_exr` (optional): Save the depth map in `exr` format.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This work presents **Video Depth Anything** based on [Depth Anything V2](https:/
 ![teaser](assets/teaser_video_v2.png)
 
 ## News
+- **2025-02-08:** Enable autocast inference. Support grayscale video, NPZ and EXR output formats.
 - **2025-01-21:** Paper, project page, code, models, and demo are all released.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ xformers
 einops
 easydict
 tqdm
+OpenEXR==3.3.1

--- a/run.py
+++ b/run.py
@@ -30,6 +30,8 @@ if __name__ == '__main__':
     parser.add_argument('--target_fps', type=int, default=-1, help='target fps of the input video, -1 means the original fps')
     parser.add_argument('--fp32', action='store_true', help='model infer with torch.float32, default is torch.float16')
     parser.add_argument('--grayscale', action='store_true', help='do not apply colorful palette')
+    parser.add_argument('--save_npz', action='store_true', help='save depths as npz')
+    parser.add_argument('--save_exr', action='store_true', help='save depths as exr')
 
     args = parser.parse_args()
 
@@ -55,6 +57,24 @@ if __name__ == '__main__':
     depth_vis_path = os.path.join(args.output_dir, os.path.splitext(video_name)[0]+'_vis.mp4')
     save_video(frames, processed_video_path, fps=fps)
     save_video(depths, depth_vis_path, fps=fps, is_depths=True, grayscale=args.grayscale)
+
+    if args.save_npz:
+        depth_npz_path = os.path.join(args.output_dir, os.path.splitext(video_name)[0]+'_depths.npz')
+        np.savez_compressed(depth_npz_path, depths=depths)
+    if args.save_exr:
+        depth_exr_dir = os.path.join(args.output_dir, os.path.splitext(video_name)[0]+'_depths_exr')
+        os.makedirs(depth_exr_dir, exist_ok=True)
+        import OpenEXR
+        import Imath
+        for i, depth in enumerate(depths):
+            output_exr = f"{depth_exr_dir}/frame_{i:05d}.exr"
+            header = OpenEXR.Header(depth.shape[1], depth.shape[0])
+            header["channels"] = {
+                "Z": Imath.Channel(Imath.PixelType(Imath.PixelType.FLOAT))
+            }
+            exr_file = OpenEXR.OutputFile(output_exr, header)
+            exr_file.writePixels({"Z": depth.tobytes()})
+            exr_file.close()
 
     
 

--- a/run.py
+++ b/run.py
@@ -28,6 +28,8 @@ if __name__ == '__main__':
     parser.add_argument('--encoder', type=str, default='vitl', choices=['vits', 'vitl'])
     parser.add_argument('--max_len', type=int, default=-1, help='maximum length of the input video, -1 means no limit')
     parser.add_argument('--target_fps', type=int, default=-1, help='target fps of the input video, -1 means the original fps')
+    parser.add_argument('--fp32', action='store_true', help='model infer with torch.float32, default is torch.float16')
+    parser.add_argument('--grayscale', action='store_true', help='do not apply colorful palette')
 
     args = parser.parse_args()
 
@@ -43,7 +45,7 @@ if __name__ == '__main__':
     video_depth_anything = video_depth_anything.to(DEVICE).eval()
 
     frames, target_fps = read_video_frames(args.input_video, args.max_len, args.target_fps, args.max_res)
-    depths, fps = video_depth_anything.infer_video_depth(frames, target_fps, input_size=args.input_size, device=DEVICE)
+    depths, fps = video_depth_anything.infer_video_depth(frames, target_fps, input_size=args.input_size, device=DEVICE, fp32=args.fp32)
     
     video_name = os.path.basename(args.input_video)
     if not os.path.exists(args.output_dir):
@@ -52,7 +54,7 @@ if __name__ == '__main__':
     processed_video_path = os.path.join(args.output_dir, os.path.splitext(video_name)[0]+'_src.mp4')
     depth_vis_path = os.path.join(args.output_dir, os.path.splitext(video_name)[0]+'_vis.mp4')
     save_video(frames, processed_video_path, fps=fps)
-    save_video(depths, depth_vis_path, fps=fps, is_depths=True)
+    save_video(depths, depth_vis_path, fps=fps, is_depths=True, grayscale=args.grayscale)
 
     
 

--- a/utils/dc_utils.py
+++ b/utils/dc_utils.py
@@ -69,7 +69,7 @@ def read_video_frames(video_path, process_length, target_fps=-1, max_res=-1):
     return frames, fps
 
 
-def save_video(frames, output_video_path, fps=10, is_depths=False):
+def save_video(frames, output_video_path, fps=10, is_depths=False, grayscale=False):
     writer = imageio.get_writer(output_video_path, fps=fps, macro_block_size=1, codec='libx264', ffmpeg_params=['-crf', '18'])
     if is_depths:
         colormap = np.array(cm.get_cmap("inferno").colors)
@@ -77,7 +77,7 @@ def save_video(frames, output_video_path, fps=10, is_depths=False):
         for i in range(frames.shape[0]):
             depth = frames[i]
             depth_norm = ((depth - d_min) / (d_max - d_min) * 255).astype(np.uint8)
-            depth_vis = (colormap[depth_norm] * 255).astype(np.uint8)
+            depth_vis = (colormap[depth_norm] * 255).astype(np.uint8) if not grayscale else depth_norm
             writer.append_data(depth_vis)
     else:
         for i in range(frames.shape[0]):

--- a/video_depth_anything/dpt_temporal.py
+++ b/video_depth_anything/dpt_temporal.py
@@ -91,6 +91,8 @@ class DPTHeadTemporal(DPTHead):
         out = F.interpolate(
             out, (int(patch_h * 14), int(patch_w * 14)), mode="bilinear", align_corners=True
         )
-        out = self.scratch.output_conv2(out)
+        ori_type = out.dtype
+        with torch.autocast(device_type="cuda", enabled=False):
+            out = self.scratch.output_conv2(out.float())
 
-        return out
+        return out.to(ori_type)

--- a/video_depth_anything/video_depth.py
+++ b/video_depth_anything/video_depth.py
@@ -102,8 +102,10 @@ class VideoDepthAnything(nn.Module):
                 cur_input[:, :OVERLAP, ...] = pre_input[:, KEYFRAMES, ...]
 
             with torch.no_grad():
-                depth = self.forward(cur_input) # depth shape: [1, T, H, W]
+                with torch.autocast(device_type=device, enabled=True):
+                    depth = self.forward(cur_input) # depth shape: [1, T, H, W]
 
+            depth = depth.to(cur_input.dtype)
             depth = F.interpolate(depth.flatten(0,1).unsqueeze(1), size=(frame_height, frame_width), mode='bilinear', align_corners=True)
             depth_list += [depth[i][0].cpu().numpy() for i in range(depth.shape[0])]
 

--- a/video_depth_anything/video_depth.py
+++ b/video_depth_anything/video_depth.py
@@ -64,7 +64,7 @@ class VideoDepthAnything(nn.Module):
         depth = F.relu(depth)
         return depth.squeeze(1).unflatten(0, (B, T)) # return shape [B, T, H, W]
     
-    def infer_video_depth(self, frames, target_fps, input_size=518, device='cuda'):
+    def infer_video_depth(self, frames, target_fps, input_size=518, device='cuda', fp32=False):
         frame_height, frame_width = frames[0].shape[:2]
         ratio = max(frame_height, frame_width) / min(frame_height, frame_width)
         if ratio > 1.78:  # we recommend to process video with ratio smaller than 16:9 due to memory limitation
@@ -102,7 +102,7 @@ class VideoDepthAnything(nn.Module):
                 cur_input[:, :OVERLAP, ...] = pre_input[:, KEYFRAMES, ...]
 
             with torch.no_grad():
-                with torch.autocast(device_type=device, enabled=True):
+                with torch.autocast(device_type=device, enabled=(not fp32)):
                     depth = self.forward(cur_input) # depth shape: [1, T, H, W]
 
             depth = depth.to(cur_input.dtype)


### PR DESCRIPTION
1. Enable autocast inference to save GPU VRAM and accelerate infer speed.
2. Support grayscale video depth visualization.
3. Support NPZ and EXR output formats.