### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy==1.23.1
+numpy==1.24.0
 torch==2.1.1
 torchvision==0.16.1
 opencv-python
 matplotlib
 pillow
-imageio==2.19.3
+imageio==2.37.0
 imageio-ffmpeg==0.4.7
 decord
 xformers==0.0.23


### PR DESCRIPTION
The old ImageIO has [RecursionError](https://github.com/imageio/imageio/issues/817), which occurs on `save_video` function in `run.py`.
A simple solution is to update the version of ImageIO, which requires numpy upgrade as well.